### PR TITLE
Add Flask app with CrewAI MCP integration

### DIFF
--- a/app/crew.py
+++ b/app/crew.py
@@ -1,0 +1,35 @@
+import os
+from crewai import Agent, Crew, Process, Task
+from crewai_tools import MCPServerAdapter
+from mcp import StreamableHTTPServerParameters
+
+
+def build_crew(query: str) -> Crew:
+    """Builds a CrewAI crew with MCP tools for the request."""
+    server_url = os.environ.get("MCP_SERVER_URL", "http://localhost:8000/mcp")
+    server_params = StreamableHTTPServerParameters(url=server_url)
+    with MCPServerAdapter(server_params) as mcp_tools:
+        agent = Agent(
+            role="SAP data quality and migration expert",
+            goal="Write SQL queries and define data migration rules",
+            backstory=(
+                "You are an experienced consultant specializing in SAP data "
+                "quality and migration. You help users craft SQL queries and "
+                "migration rules to move data between systems."),
+            llm="gpt-4.1",
+            tools=mcp_tools,
+            verbose=True,
+        )
+
+        task = Task(
+            description="{query}",
+            agent=agent,
+        )
+
+        crew = Crew(
+            agents=[agent],
+            tasks=[task],
+            process=Process.sequential,
+        )
+        crew.inputs = {"query": query}
+        return crew

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,23 @@
+from flask import Flask, jsonify, request
+from .crew import build_crew
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.route('/analyze', methods=['POST'])
+    def analyze():
+        data = request.get_json(force=True)
+        query = data.get('query')
+        if not query:
+            return jsonify({'error': 'query is required'}), 400
+
+        crew = build_crew(query)
+        result = crew.kickoff()
+        return jsonify({'result': result})
+
+    return app
+
+if __name__ == '__main__':
+    app = create_app()
+    app.run(host='0.0.0.0', port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+crewai
+crewai-tools[mcp]
+openai

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,26 @@
+import json
+from unittest.mock import patch
+from flask.testing import FlaskClient
+from app.main import create_app
+
+
+def test_analyze_route_success():
+    app = create_app()
+    client: FlaskClient = app.test_client()
+    with patch('app.main.build_crew') as mock_build_crew:
+        mock_crew = mock_build_crew.return_value
+        mock_crew.kickoff.return_value = 'ok'
+        response = client.post('/analyze', json={'query': 'SELECT * FROM table'})
+        assert response.status_code == 200
+        assert response.json == {'result': 'ok'}
+        mock_build_crew.assert_called_once()
+        mock_crew.kickoff.assert_called_once()
+
+
+def test_analyze_route_missing_query():
+    app = create_app()
+    client: FlaskClient = app.test_client()
+    response = client.post('/analyze', json={})
+    assert response.status_code == 400
+    assert response.json == {'error': 'query is required'}
+


### PR DESCRIPTION
## Summary
- add Flask web app using CrewAI
- configure SAP migration expert agent with GPT-4.1
- include MCP server adapter tool usage
- add simple unit tests for the `/analyze` endpoint
- document dependencies in requirements.txt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683f00e2ece483248bdd42ac32286b24