### PR TITLE
Add web page for crew interactions

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,20 +1,35 @@
-from flask import Flask, jsonify, request
+from flask import Flask, request, render_template_string
 from .crew import build_crew
 
 
 def create_app() -> Flask:
     app = Flask(__name__)
 
-    @app.route('/analyze', methods=['POST'])
-    def analyze():
-        data = request.get_json(force=True)
-        query = data.get('query')
-        if not query:
-            return jsonify({'error': 'query is required'}), 400
+    TEMPLATE = """
+    <!doctype html>
+    <title>Data Agent</title>
+    <h1>Query Analyzer</h1>
+    <form method=post>
+      <input name=query placeholder="Enter statement">
+      <button type=submit>Analyze</button>
+    </form>
+    {% if error %}<p>{{ error }}</p>{% endif %}
+    {% if result %}<pre>{{ result }}</pre>{% endif %}
+    """
 
-        crew = build_crew(query)
-        result = crew.kickoff()
-        return jsonify({'result': result})
+    @app.route('/', methods=['GET', 'POST'])
+    def index():
+        error = None
+        result = None
+        if request.method == 'POST':
+            query = request.form.get('query', '').strip()
+            if not query:
+                error = 'query is required'
+            else:
+                crew = build_crew(query)
+                result = crew.kickoff()
+
+        return render_template_string(TEMPLATE, error=error, result=result)
 
     return app
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,30 +1,37 @@
-import json
 import os
 import sys
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from unittest.mock import patch
 from flask.testing import FlaskClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 from app.main import create_app
 
 
-def test_analyze_route_success():
+def test_index_get():
+    app = create_app()
+    client: FlaskClient = app.test_client()
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b'<form' in response.data
+
+
+def test_index_post_success():
     app = create_app()
     client: FlaskClient = app.test_client()
     with patch('app.main.build_crew') as mock_build_crew:
         mock_crew = mock_build_crew.return_value
         mock_crew.kickoff.return_value = 'ok'
-        response = client.post('/analyze', json={'query': 'SELECT * FROM table'})
+        response = client.post('/', data={'query': 'SELECT * FROM table'})
         assert response.status_code == 200
-        assert response.json == {'result': 'ok'}
+        assert b'ok' in response.data
         mock_build_crew.assert_called_once()
         mock_crew.kickoff.assert_called_once()
 
 
-def test_analyze_route_missing_query():
+def test_index_post_missing_query():
     app = create_app()
     client: FlaskClient = app.test_client()
-    response = client.post('/analyze', json={})
-    assert response.status_code == 400
-    assert response.json == {'error': 'query is required'}
-
+    response = client.post('/', data={'query': ''})
+    assert response.status_code == 200
+    assert b'query is required' in response.data


### PR DESCRIPTION
## Summary
- build a simple HTML form for query analysis and remove `/analyze`
- update tests to cover new form-driven interactions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683f0970765c83249fee649cc24b64b2